### PR TITLE
libnpp v12.4.1.87

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 # Ignore all files and folders in root
 *
 !/conda-forge.yml
+!/abs.yaml
 
 # Don't ignore any files/folders if the parent folder is 'un-ignored'
 # This also avoids warnings when adding an already-checked file with an ignored parent.

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,9 @@
+# build_parameters:
+#   - "--suppress-variables"
+#   #- "--skip-existing"
+#   - "--error-overlinking"
+
+# staging_channel_upload_target: ctk-12.9-build-4
+
+# channels:
+#   - https://staging.continuum.io/pbp/ctk-12.9-build-4

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,6 +1,3 @@
 arm_variant_type: # [aarch64]
   - sbsa          # [aarch64]
-  - tegra         # [aarch64]
-
-c_stdlib_version:  # [linux]
-  - "2.28"         # [linux]
+#  - tegra         # [aarch64]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,17 +26,25 @@ source:
   sha256: cfcfbf59e4e5ce71113c058bd4eba3dd56e4db080932146d4047c0d44b4a558e  # [win]
 
 build:
-  number: 1
+  number: 0
   binary_relocation: false
-  skip: true  # [osx or ppc64le]
+  skip: true  # [osx]
 
 requirements:
   build:
     - cf-nvidia-tools 1.*  # [linux]
-    - patchelf <0.18.0                      # [linux]
+    - patchelf <0.18.0     # [linux]
 
 outputs:
   - name: libnpp
+    build:
+      binary_relocation: false
+      missing_dso_whitelist:
+        # Needed for the use of conda-build's --error-overlinking command-line argument
+        - '*libgcc_s.so*'  # [linux]
+      overlinking_ignore_patterns:
+        # Workaround for LIEF's 'not a valid TAG' error
+        - '*libnpp*.so*'  # [linux and aarch64]
     files:
       - lib/libnpp*.so.*                            # [linux]
       - targets/{{ target_name }}/lib/libnpp*.so.*  # [linux]
@@ -69,10 +77,12 @@ outputs:
       license: LicenseRef-NVIDIA-End-User-License-Agreement
       license_file: LICENSE
       license_url: https://docs.nvidia.com/cuda/eula/index.html
+      license_family: Other
       summary: NPP native runtime libraries
       description: |
         NPP native runtime libraries
       doc_url: https://docs.nvidia.com/cuda/npp/index.html
+      dev_url: https://docs.nvidia.com/cuda/npp/index.html
 
   - name: libnpp-dev
     build:
@@ -117,10 +127,12 @@ outputs:
       license: LicenseRef-NVIDIA-End-User-License-Agreement
       license_file: LICENSE
       license_url: https://docs.nvidia.com/cuda/eula/index.html
+      license_family: Other
       summary: NPP native runtime libraries
       description: |
         NPP native runtime libraries
       doc_url: https://docs.nvidia.com/cuda/npp/index.html
+      dev_url: https://docs.nvidia.com/cuda/npp/index.html
 
   - name: libnpp-static
     build:
@@ -149,20 +161,24 @@ outputs:
       license: LicenseRef-NVIDIA-End-User-License-Agreement
       license_file: LICENSE
       license_url: https://docs.nvidia.com/cuda/eula/index.html
+      license_fmaily: Other
       summary: NPP native runtime libraries
       description: |
         NPP native runtime libraries
       doc_url: https://docs.nvidia.com/cuda/npp/index.html
+      dev_url: https://docs.nvidia.com/cuda/npp/index.html
 
 about:
   home: https://developer.nvidia.com/npp
   license: LicenseRef-NVIDIA-End-User-License-Agreement
   license_file: LICENSE
   license_url: https://docs.nvidia.com/cuda/eula/index.html
+  license_family: Other
   summary: NPP native runtime libraries
   description: |
     NPP native runtime libraries
   doc_url: https://docs.nvidia.com/cuda/npp/index.html
+  dev_url: https://docs.nvidia.com/cuda/npp/index.html
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
libnpp 12.4.1.87

**Destination channel:** defaults

### Links

- [PKG-12784](https://anaconda.atlassian.net/browse/PKG-12784) 
- [CUDA 12.9 release notes](https://docs.nvidia.com/cuda/archive/12.9.1/cuda-toolkit-release-notes/index.html) for list of packages, version numbers, etc.

### Explanation of changes:

- CUDA 12.9 release
- Based on upstream feedstock's `12.x` branch.
- Added `abs.yaml` for possible use of staging channels in future builds
- Removed Tegra builds from `cbc.yaml`. We may enable them in the future.
- Kept static library packages as they are dependencies for `cuda-libraries-static` package.


[PKG-12784]: https://anaconda.atlassian.net/browse/PKG-12784?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ